### PR TITLE
Sample setup for IAM Federated Access

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -1,0 +1,12 @@
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  format-code:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: ministryofjustice/github-actions/code-formatter@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# modernisation-platform-terraform-iam-federated-access
+
+This repository holds a Terraform module that creates an Auth0 application and associated integrations to enable IAM Federated Access in AWS.
+
+## Usage
+```
+module "iam_federation" {
+  source              = "github.com/ministryofjustice/modernisation-platform-terraform-iam-federated-access"
+  auth0_tenant_domain = ""
+  auth0_client_id     = ""
+  auth0_client_secret = ""
+  auth0_debug         = false
+}
+```
+
+## Inputs
+| Name                | Description                                                         | Type    | Default | Required |
+|---------------------|---------------------------------------------------------------------|---------|---------|----------|
+| auth0_tenant_domain | Tenant domain from the Auth0 account to create applicable resources | string  | n/a     | yes      |
+| auth0_client_id     | Auth0 application (Machine to Machine) client ID to utilise         | string  | n/a     | yes      |
+| auth0_client_secret | Auth0 application (Machine to Machine) client secret to utilise     | string  | n/a     | yes      |
+| auth0_debug         | Whether to turn Auth0 debugging on or off                           | boolean | `false` | no       |
+
+## Outputs
+| Name            | Description                            | Sensitive |
+|-----------------|----------------------------------------|-----------|
+| saml_login_page | URL for the SAML login page from Auth0 | no        |

--- a/auth0-rules/sample-assume-role.js
+++ b/auth0-rules/sample-assume-role.js
@@ -1,0 +1,11 @@
+function (user, context, callback) {
+  user.awsRole = 'arn:aws:iam::' + configuration.AWS_ACCOUNT_ID + ':role/' + configuration.AWS_ROLE_NAME + ',arn:aws:iam::' + configuration.AWS_ACCOUNT_ID + ':saml-provider/' + configuration.AWS_SAML_PROVIDER_NAME
+  user.awsRoleSession = user.name
+
+  context.samlConfiguration.mappings = {
+    'https://aws.amazon.com/SAML/Attributes/Role': 'awsRole',
+    'https://aws.amazon.com/SAML/Attributes/RoleSessionName': 'awsRoleSession'
+  }
+
+  callback(null, user, context)
+}

--- a/auth0.tf
+++ b/auth0.tf
@@ -1,0 +1,56 @@
+data "aws_iam_account_alias" "current" {}
+data "aws_caller_identity" "current" {}
+
+# Auth0: Client setup
+resource "auth0_client" "saml" {
+  name        = "AWS-SAML: ${data.aws_iam_account_alias.current.account_alias}"
+  description = "SAML provider for the ${data.aws_iam_account_alias.current.account_alias} account"
+  callbacks   = ["https://signin.aws.amazon.com/saml"]
+  logo_uri    = "https://ministryofjustice.github.io/assets/moj-crest.png"
+
+  addons {
+    samlp {
+      audience = "https://signin.aws.amazon.com/saml"
+
+      mappings = {
+        email = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
+        name  = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
+      }
+
+      create_upn_claim                   = false
+      passthrough_claims_with_no_mapping = false
+      map_unknown_claims_as_is           = false
+      map_identities                     = false
+      name_identifier_format             = "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
+
+      name_identifier_probes = [
+        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
+      ]
+
+    }
+  }
+}
+
+# Auth0 Rules: Set the configuration variables,
+# which are accessible in Auth0 rules
+resource "auth0_rule_config" "aws_account_id" {
+  key   = "AWS_ACCOUNT_ID"
+  value = data.aws_caller_identity.current.account_id
+}
+
+resource "auth0_rule_config" "aws_saml_provider_name" {
+  key   = "AWS_SAML_PROVIDER_NAME"
+  value = aws_iam_saml_provider.auth0.name
+}
+
+resource "auth0_rule_config" "aws_role_name" {
+  key   = "AWS_ROLE_NAME"
+  value = aws_iam_role.federated_role.name
+}
+
+# Auth0 Rules: Attach JavaScript files from this repository
+resource "auth0_rule" "sample" {
+  name    = "sample"
+  script  = file("${path.module}/auth0-rules/sample-assume-role.js")
+  enabled = true
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,8 @@
+provider "external" {}
+
+provider "auth0" {
+  domain        = var.auth0_tenant_domain
+  client_id     = var.auth0_client_id
+  client_secret = var.auth0_client_secret
+  debug         = var.auth0_debug
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "saml_login_page" {
+  value = "https://${var.auth0_tenant_domain}/samlp/${auth0_client.saml.client_id}"
+}

--- a/saml.tf
+++ b/saml.tf
@@ -1,0 +1,42 @@
+data "external" "metadata" {
+  program = [
+    "bash",
+    "-c",
+    "jq -sR '{ content : . }' <<<$(curl -s https://${var.auth0_tenant_domain}/samlp/metadata/${auth0_client.saml.client_id})",
+  ]
+}
+
+resource "aws_iam_saml_provider" "auth0" {
+  name                   = "auth0"
+  saml_metadata_document = data.external.metadata.result["content"]
+}
+
+data "aws_iam_policy_document" "federated_role_trust_policy" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_saml_provider.auth0.arn]
+    }
+
+    actions = ["sts:AssumeRoleWithSAML"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "SAML:aud"
+      values   = ["https://signin.aws.amazon.com/saml"]
+    }
+  }
+}
+
+resource "aws_iam_role" "federated_role" {
+  name                 = "auth0"
+  assume_role_policy   = data.aws_iam_policy_document.federated_role_trust_policy.json
+  max_session_duration = 12 * 3600
+}
+
+resource "aws_iam_role_policy_attachment" "federatedAdminAttachment" {
+  role       = aws_iam_role.federated_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,20 @@
+variable "auth0_tenant_domain" {
+  description = "Auth0 tenant domain"
+  type        = string
+}
+
+variable "auth0_client_id" {
+  description = "Auth0 Client ID"
+  type        = string
+}
+
+variable "auth0_client_secret" {
+  description = "Auth0 Client Secret"
+  type        = string
+}
+
+variable "auth0_debug" {
+  description = "Auth0 Debug Flag"
+  type        = bool
+  default     = false
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    auth0 = {
+      source = "terraform-providers/auth0"
+    }
+    aws = {
+      source = "hashicorp/aws"
+    }
+    external = {
+      source = "hashicorp/external"
+    }
+  }
+}


### PR DESCRIPTION
This PR creates a sample setup for IAM Federated Access, which includes:
- Provisioning an application in Auth0, to use as an IdP
- Configuring dynamic Auth0 rules to allow role assumption after a successful login
- Creates an IAM SAML Provider in AWS, and associated roles and policies

This is a proof-of-concept for federated access.