### PR TITLE
Configure a GitHub social connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,27 @@ This repository holds a Terraform module that creates an Auth0 application and a
 ```
 module "iam_federation" {
   source              = "github.com/ministryofjustice/modernisation-platform-terraform-iam-federated-access"
-  auth0_tenant_domain = ""
-  auth0_client_id     = ""
-  auth0_client_secret = ""
-  auth0_debug         = false
+  auth0_tenant_domain        = ""
+  auth0_client_id            = ""
+  auth0_client_secret        = ""
+  auth0_debug                = false
+  auth0_github_client_id     = ""
+  auth0_github_client_secret = ""
+  auth0_github_allowed_orgs  = ["ministryofjustice"]
+
 }
 ```
 
 ## Inputs
-| Name                | Description                                                         | Type    | Default | Required |
-|---------------------|---------------------------------------------------------------------|---------|---------|----------|
-| auth0_tenant_domain | Tenant domain from the Auth0 account to create applicable resources | string  | n/a     | yes      |
-| auth0_client_id     | Auth0 application (Machine to Machine) client ID to utilise         | string  | n/a     | yes      |
-| auth0_client_secret | Auth0 application (Machine to Machine) client secret to utilise     | string  | n/a     | yes      |
-| auth0_debug         | Whether to turn Auth0 debugging on or off                           | boolean | `false` | no       |
+| Name                       | Description                                                         | Type    | Default | Required |
+|----------------------------|---------------------------------------------------------------------|---------|---------|----------|
+| auth0_tenant_domain        | Tenant domain from the Auth0 account to create applicable resources | string  | n/a     | yes      |
+| auth0_client_id            | Auth0 application (Machine to Machine) client ID to utilise         | string  | n/a     | yes      |
+| auth0_client_secret        | Auth0 application (Machine to Machine) client secret to utilise     | string  | n/a     | yes      |
+| auth0_debug                | Whether to turn Auth0 debugging on or off                           | boolean | `false` | no       |
+| auth0_github_client_id     | GitHub OAuth app client ID for an Auth0 social connection           | string  | n/a     | yes      |
+| auth0_github_client_secret | GitHub OAuth app client secret for an Auth0 social connection       | string  | n/a     | yes      |
+| auth0_github_allowed_orgs  | A list of organisations a user has to be part of to authenticate    | list    | n/a     | yes      |
 
 ## Outputs
 | Name            | Description                            | Sensitive |

--- a/auth0-rules/allow-github-organisations.js
+++ b/auth0-rules/allow-github-organisations.js
@@ -6,7 +6,7 @@
   Otherwise, it will reject the user.
 */
 async function (user, context, callback) {
-  const allowedOrganisations = configuration.ALLOWED_ORGANISATIONS
+  const allowedOrganisations = JSON.parse(configuration.ALLOWED_ORGANISATIONS)
 
   if (context.connectionStrategy === 'github') {
     const identity = user.identities.find(identity => identity.provider === 'github')

--- a/auth0-rules/allow-github-organisations.js
+++ b/auth0-rules/allow-github-organisations.js
@@ -1,0 +1,31 @@
+/*
+  This rule checks if a user is:
+  - signing in with GitHub
+  - is part of an allowed organisation
+  If so, it will start processing the next rule in the list or authorise a users access.
+  Otherwise, it will reject the user.
+*/
+async function (user, context, callback) {
+  const allowedOrganisations = configuration.ALLOWED_ORGANISATIONS
+
+  if (context.connectionStrategy === 'github') {
+    const identity = user.identities.find(identity => identity.provider === 'github')
+
+    if (identity) {
+      const { Octokit } = require('@octokit/rest@17.1.4')
+      const octokit = new Octokit({ auth: identity.access_token })
+
+      // Get the authenticated user's GitHub organisation memberships
+      const userOrganisations = await octokit.request('GET /user/orgs').catch(error => callback(new Error(`Error retrieving orgs from GitHub: ${error}`)))
+
+      // Check if a user is part of an allowed organisation
+      const authorised = userOrganisations.data.map(organisation => organisation.login).some(organisation => allowedOrganisations.includes(organisation))
+
+      if (authorised) {
+        return callback(null, user, context)
+      }
+    }
+  }
+
+  return callback(new UnauthorizedError('Access denied.'))
+}

--- a/auth0-rules/map-teams-to-roles.js
+++ b/auth0-rules/map-teams-to-roles.js
@@ -1,0 +1,44 @@
+/*
+  This rule checks if a user is:
+  - signing in with GitHub
+  - has a team membership within an allowed organisation
+  - automatically maps team memberships to an AWS role
+*/
+async function (user, context, callback) {
+  const allowedOrganisations = configuration.ALLOWED_ORGANISATIONS
+
+  if (context.connectionStrategy === 'github') {
+    const identity = user.identities.find(identity => identity.provider === 'github')
+
+    if (identity) {
+      const { Octokit } = require('@octokit/rest@17.1.4')
+      const octokit = new Octokit({ auth: identity.access_token })
+
+      // Get the authenticate user's GitHub teams membership
+      const userOrganisationTeams = await octokit.request('GET /user/teams').catch(error => callback(new Error(`Error retrieving user teams from GitHub: ${error}`)))
+
+      // Set AWS IdP arn and role arn
+      const idpArn = `arn:aws:iam::${configuration.AWS_ACCOUNT_ID}:saml-provider/${configuration.AWS_SAML_PROVIDER_NAME}`
+      const roleArnBase = `arn:aws:iam::${configuration.AWS_ACCOUNT_ID}:role/`
+
+      // Map teams from allowed organisations into AWS roles
+      user.awsRole = userOrganisationTeams.data.filter(team => allowedOrganisations.includes(team.organization.login)).map(team => `${roleArnBase + team.slug},${idpArn}`)
+
+      // Set a users role session name (this uses a GitHub username, e.g. auth0/jakemulley)
+      user.awsRoleSession = user.nickname
+
+      // Configure SAML mappings
+      context.samlConfiguration.mappings = {
+        'https://aws.amazon.com/SAML/Attributes/Role': 'awsRole',
+        'https://aws.amazon.com/SAML/Attributes/RoleSessionName': 'awsRoleSession'
+      }
+
+      // If the authenticated user isn't part of any teams in an allowed organisation, we won't grant them access.
+      if(user.awsRole.length) {
+        return callback(null, user, context)
+      }
+
+      return callback(new UnauthorizedError('Access denied: no team membership.'))
+    }
+  }
+}

--- a/auth0-rules/map-teams-to-roles.js
+++ b/auth0-rules/map-teams-to-roles.js
@@ -5,7 +5,7 @@
   - automatically maps team memberships to an AWS role
 */
 async function (user, context, callback) {
-  const allowedOrganisations = configuration.ALLOWED_ORGANISATIONS
+  const allowedOrganisations = JSON.parse(configuration.ALLOWED_ORGANISATIONS)
 
   if (context.connectionStrategy === 'github') {
     const identity = user.identities.find(identity => identity.provider === 'github')

--- a/auth0.tf
+++ b/auth0.tf
@@ -65,7 +65,7 @@ resource "auth0_rule_config" "aws_role_name" {
 
 resource "auth0_rule_config" "github_allowed_organisations" {
   key   = "ALLOWED_ORGANISATIONS"
-  value = var.auth0_github_allowed_orgs
+  value = jsonencode(var.auth0_github_allowed_orgs)
 }
 
 # Auth0 Rules: Attach rules from this repository

--- a/auth0.tf
+++ b/auth0.tf
@@ -7,6 +7,7 @@ resource "auth0_client" "saml" {
   description = "SAML provider for the ${data.aws_iam_account_alias.current.account_alias} account"
   callbacks   = ["https://signin.aws.amazon.com/saml"]
   logo_uri    = "https://ministryofjustice.github.io/assets/moj-crest.png"
+  app_type    = "regular_web"
 
   addons {
     samlp {
@@ -24,10 +25,24 @@ resource "auth0_client" "saml" {
       name_identifier_format             = "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
 
       name_identifier_probes = [
+        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
         "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
       ]
 
     }
+  }
+}
+
+# # Auth0: Connection setup
+resource "auth0_connection" "github_saml_connection" {
+  name            = "GitHub"
+  strategy        = "github"
+  enabled_clients = [auth0_client.saml.id]
+  options {
+    client_id     = var.auth0_github_client_id
+    client_secret = var.auth0_github_client_secret
+    # Scope definitions aren't supported, but these are the ones you need in Auth0
+    scopes = ["read:user", "read:org"]
   }
 }
 
@@ -48,9 +63,22 @@ resource "auth0_rule_config" "aws_role_name" {
   value = aws_iam_role.federated_role.name
 }
 
-# Auth0 Rules: Attach JavaScript files from this repository
-resource "auth0_rule" "sample" {
-  name    = "sample"
-  script  = file("${path.module}/auth0-rules/sample-assume-role.js")
+resource "auth0_rule_config" "github_allowed_organisations" {
+  key   = "ALLOWED_ORGANISATIONS"
+  value = var.auth0_github_allowed_orgs
+}
+
+# Auth0 Rules: Attach rules from this repository
+resource "auth0_rule" "allow_github_organisations" {
+  name    = "Allow specific GitHub Organisations"
+  script  = file("${path.module}/auth0-rules/allow-github-organisations.js")
   enabled = true
+  order   = 10
+}
+
+resource "auth0_rule" "map_teams_to_roles" {
+  name    = "Map teams to roles"
+  script  = file("${path.module}/auth0-rules/map-teams-to-roles.js")
+  enabled = true
+  order   = 20
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,17 +4,32 @@ variable "auth0_tenant_domain" {
 }
 
 variable "auth0_client_id" {
-  description = "Auth0 Client ID"
+  description = "Auth0 client ID (from a Machine to Machine application)"
   type        = string
 }
 
 variable "auth0_client_secret" {
-  description = "Auth0 Client Secret"
+  description = "Auth0 client secret (from a Machine to Machine application)"
   type        = string
 }
 
 variable "auth0_debug" {
-  description = "Auth0 Debug Flag"
+  description = "Auth0 debug flag"
   type        = bool
   default     = false
+}
+
+variable "auth0_github_client_id" {
+  description = "Auth0: GitHub client ID"
+  type        = string
+}
+
+variable "auth0_github_client_secret" {
+  description = "Auth0: GitHub client secret"
+  type        = string
+}
+
+variable "auth0_github_allowed_orgs" {
+  description = "A list of GitHub organisations a user has to be part of"
+  type        = list(string)
 }


### PR DESCRIPTION
This PR:
- Configures a GitHub social connection within Auth0
- Adds Auth0 rules to ensure a user trying to authenticate is part of the correct organisation
- Maps an users organisation team membership to an AWS role and authenticates the user

This allows IAM Federated Access via GitHub/Auth0.